### PR TITLE
Add error backtrace to safe_run output

### DIFF
--- a/lib/sensu/extension.rb
+++ b/lib/sensu/extension.rb
@@ -98,7 +98,9 @@ module Sensu
         begin
           data ? run(data.dup, &callback) : run(&callback)
         rescue => error
-          callback.call(error.to_s, 2)
+          klass = error.class.name
+          backtrace = error.backtrace.map { |x| "\tfrom #{x}" }.join("\n")
+          callback.call("#{klass}: #{error}\n#{backtrace}", 2)
         end
       end
 

--- a/sensu-extension.gemspec
+++ b/sensu-extension.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "bouncy-castle-java" if RUBY_PLATFORM == "java"
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -74,7 +74,7 @@ describe "Sensu::Extension::Base" do
     async_wrapper do
       @extension.safe_run do |output, status|
         raise "boom" if status == 0
-        expect(output).to eq("boom")
+        expect(output.split("\n").first).to eq("RuntimeError: boom")
         expect(status).to eq(2)
         async_done
       end


### PR DESCRIPTION
Better handling of errors from mutator extensions, etc.
