### PR TITLE
Add ruby 2.4.0 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.2.0
   - 2.2.3
   - 2.3.0
+  - 2.4.0
   - jruby-9.0.5.0
 notifications:
   irc:

--- a/sensu-extension.gemspec
+++ b/sensu-extension.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "10.5.0"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "codeclimate-test-reporter" unless RUBY_VERSION < "1.9"
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,11 +1,6 @@
 require "rspec"
 require "eventmachine"
 
-unless RUBY_VERSION < "1.9" || RUBY_PLATFORM =~ /java/
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
-end
-
 module Helpers
   def timer(delay, &callback)
     periodic_timer = EM::PeriodicTimer.new(delay) do


### PR DESCRIPTION
## Description
Adds Ruby 2.4.0 to the list of tested rubies on Travis CI.

## Related Issue


## Motivation and Context
We'd like to ensure that Sensu can run on the latest ruby version.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
